### PR TITLE
[NSoC'26] Fixed searchbar logic and ui

### DIFF
--- a/style.css
+++ b/style.css
@@ -849,6 +849,7 @@ body[class*="theme-"] {
 
 .game-card:hover:not(.locked) {
     box-shadow: 0 15px 50px var(--glow) !important;
+}
 
 /* --- SEARCH & FILTER SECTION --- */
 .hub-controls {
@@ -945,5 +946,4 @@ body[class*="theme-"] {
 }
 .hidden {
     display: none !important;
- main
 }


### PR DESCRIPTION
Reference to #37 
I added the missing closing brace } to properly close the preceding CSS rule.
I removed the invalid  main text from the end of the file.

<img width="1434" height="570" alt="Screenshot 2026-04-28 at 9 44 49 AM" src="https://github.com/user-attachments/assets/ce6892ff-53b3-4115-b804-e5c00900e71f" />
