### PR TITLE
[nsoc] Fix Auto Label Workflow Permissions

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   add-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The \Auto Label NSOC Issues\ workflow was failing with a 'Resource not accessible by integration' error because it lacked the required permissions to add labels to issues. This PR adds the \permissions: issues: write\ block to fix the CI.